### PR TITLE
Windows CI: add mitigation strategy

### DIFF
--- a/ci/win_test_installer.cmd
+++ b/ci/win_test_installer.cmd
@@ -12,6 +12,10 @@ echo %PATH%
 echo %PYTHONPATH%
 echo %NEURONHOME%
 
+:: Mitigation strategy -> for reasons uknown(thank you Windows), association.hoc.out may not be generated from previous step.
+:: If so, try again to generate it. No wait required like previous strategies, we rely on testing entropy from this point on.
+if not exist association.hoc.out (start /wait /REALTIME %cd%\ci\association.hoc)
+
 :: test all pythons
 C:\Python36\python -c "import neuron; neuron.test(); neuron.test_rxd(); quit()" || set "errorfound=y"
 C:\Python37\python -c "import neuron; neuron.test(); neuron.test_rxd(); quit()" || set "errorfound=y"


### PR DESCRIPTION
* launch association.hoc again if `association.hoc.out` not found